### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ then in .bashrc or .zshrc:
 source ./listbox/listbox.sh
 ```
 
+### With [Fig](https://fig.io)
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `listbox` in just one click.
+
+<a href="https://fig.io/plugins/other/listbox_gko" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### With [antigen](https://github.com/zsh-users/antigen)
 
 In your .zshrc


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`listbox` is already listed in the store so we'd love to have it listed as a download method on your README.

Thanks so much and please let me know if you have any questions!